### PR TITLE
Fix code scanning alert no. 774: Potential use after free

### DIFF
--- a/deps/openssl/openssl/ssl/statem/extensions_clnt.c
+++ b/deps/openssl/openssl/ssl/statem/extensions_clnt.c
@@ -1671,6 +1671,11 @@ int tls_parse_stoc_alpn(SSL *s, PACKET *pkt, unsigned int context, X509 *x,
         /* ALPN not consistent with the old session so cannot use early_data */
         s->ext.early_data_ok = 0;
     }
+
+    if (s->s3.alpn_selected == NULL) {
+        SSLfatal(s, SSL_AD_INTERNAL_ERROR, ERR_R_INTERNAL_ERROR);
+        return 0;
+    }
     if (!s->hit) {
         /*
          * This is a new session and so alpn_selected should have been


### PR DESCRIPTION
Fixes [https://github.com/akaday/potential-octo-tribble/security/code-scanning/774](https://github.com/akaday/potential-octo-tribble/security/code-scanning/774)

To fix the potential use-after-free error, we need to ensure that `s->s3.alpn_selected` is not accessed after it has been freed unless it has been successfully reallocated. We can achieve this by adding a check to ensure that `s->s3.alpn_selected` is not `NULL` before accessing it at line 1670. Additionally, we should ensure that any error paths properly handle the case where memory allocation fails.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
