### PR TITLE
Refactor tls_construct_ctos_* and tls_parse_stoc_* functions

### DIFF
--- a/deps/openssl/openssl/ssl/statem/extensions_srvr.c
+++ b/deps/openssl/openssl/ssl/statem/extensions_srvr.c
@@ -36,6 +36,15 @@
                          + MAX_COOKIE_SIZE)
 
 /*
+ * Macro for repetitive PACKET operations in tls_parse_stoc_* functions
+ */
+#define PARSE_PACKET(pkt, len, data, err_code) \
+    if (!PACKET_get_1_len(pkt, &len) || !PACKET_get_bytes(pkt, &data, len)) { \
+        SSLfatal(s, SSL_AD_DECODE_ERROR, err_code); \
+        return 0; \
+    }
+
+/*
  * Parse the client's renegotiation binding and abort if it's not right
  */
 int tls_parse_ctos_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
@@ -44,12 +53,7 @@ int tls_parse_ctos_renegotiate(SSL *s, PACKET *pkt, unsigned int context,
     unsigned int ilen;
     const unsigned char *data;
 
-    /* Parse the length byte */
-    if (!PACKET_get_1(pkt, &ilen)
-        || !PACKET_get_bytes(pkt, &data, ilen)) {
-        SSLfatal(s, SSL_AD_DECODE_ERROR, SSL_R_RENEGOTIATION_ENCODING_ERR);
-        return 0;
-    }
+    PARSE_PACKET(pkt, ilen, data, SSL_R_RENEGOTIATION_ENCODING_ERR)
 
     /* Check that the extension matches */
     if (ilen != s->s3.previous_client_finished_len) {


### PR DESCRIPTION
Refactor repetitive code blocks in `tls_construct_ctos_*` and `tls_parse_stoc_*` functions using macros.

* **Introduce Macros:**
  - Add `WPACKET_EXTENSION` macro in `extensions_clnt.c` for repetitive WPACKET operations.
  - Add `PARSE_PACKET` macro in `extensions_srvr.c` for repetitive PACKET operations.

* **Refactor `tls_construct_ctos_*` Functions:**
  - Use `WPACKET_EXTENSION` macro in `tls_construct_ctos_renegotiate`, `tls_construct_ctos_server_name`, `tls_construct_ctos_maxfragmentlen`, `tls_construct_ctos_srp`, `tls_construct_ctos_ec_pt_formats`, and `tls_construct_ctos_alpn` functions.

* **Refactor `tls_parse_stoc_*` Functions:**
  - Use `PARSE_PACKET` macro in `tls_parse_ctos_renegotiate` function.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/potential-octo-tribble/pull/52?shareId=849a363f-2570-4176-ad1c-21a5e46f703b).